### PR TITLE
code.gs: new logic for monospace detection

### DIFF
--- a/app/Code.gs
+++ b/app/Code.gs
@@ -256,6 +256,19 @@ function asciidocHandleList(child) {
   return result;
 }
 
+/** Guess if the text is code by looking at the font family. */
 function isTextCode(text) {
-  return text.getFontFamily() == DocumentApp.FontFamily.CONSOLAS || text.getFontFamily() == DocumentApp.FontFamily.COURIER_NEW;
+  // Things will be better if Google Fonts can tell us about a font
+  var i, fontFamily = text.getFontFamily(), /* Now it returns a string! */
+  monospaceFonts = ['Consolas', 'Courier New', 'Source Code Pro'];
+  // See ES7 Array.prototype.includes(elem, pos)
+  for (i = 0; i < monospaceFonts.length; i++) {
+    if (fontFamily === monospaceFonts[i]) {
+      return true;
+    }
+  }
+  // Last Try: Assume it's mono if it ends with ' Mono'.
+  // This works for all Google Fonts as of 2016-10-21.
+  // See ES6 String.prototype.endsWith(str, pos).
+  return fontFamily.indexOf(' Mono') === fontFamily.length;
 }

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -270,5 +270,5 @@ function isTextCode(text) {
   // Last Try: Assume it's mono if it ends with ' Mono'.
   // This works for all Google Fonts as of 2016-10-21.
   // See ES6 String.prototype.endsWith(str, pos).
-  return fontFamily.indexOf(' Mono') === fontFamily.length;
+  return fontFamily.indexOf(' Mono') === fontFamily.length - 5;
 }

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -261,6 +261,9 @@ function isTextCode(text) {
   // Things will be better if Google Fonts can tell us about a font
   var i, fontFamily = text.getFontFamily(), /* Now it returns a string! */
   monospaceFonts = ['Consolas', 'Courier New', 'Source Code Pro'];
+  if (fontFamily === null) {
+    return false; // Handle null early.. It means multil=ple values.
+  }
   // See ES7 Array.prototype.includes(elem, pos)
   for (i = 0; i < monospaceFonts.length; i++) {
     if (fontFamily === monospaceFonts[i]) {

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -262,7 +262,7 @@ function isTextCode(text) {
   var i, fontFamily = text.getFontFamily(), /* Now it returns a string! */
   monospaceFonts = ['Consolas', 'Courier New', 'Source Code Pro'];
   if (fontFamily === null) {
-    return false; // Handle null early.. It means multil=ple values.
+    return false; // Handle null early.. It means multiple values.
   }
   // See ES7 Array.prototype.includes(elem, pos)
   for (i = 0; i < monospaceFonts.length; i++) {


### PR DESCRIPTION
This changeset uses the feature that the new font family API returns a string. It also does an extra neat guess by checking if `fontFamily.endsWith(' Mono')`.