### PR TITLE
Implement Strikethru and remove underline conflict

### DIFF
--- a/app/Code.gs
+++ b/app/Code.gs
@@ -150,38 +150,44 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
   var isBold = text.isBold(offset);
   var isItalic = text.isItalic(offset);
   var isUnderline = text.isUnderline(offset);
-  var isPlain = !isBold && !isItalic && !isUnderline;
+  var isStrikethrough = text.isStrikethrough(offset);
+  // var isPlain = ! (isBold || isItalic || isUnderline || isStrikethrough);
+  // FIXME: getTextAttributeIndices doesn't split on different fonts,
+  // makeing this almost useless
   var isCode = isTextCode(text);
   // Prefix markup
   if (isUnderline) {
-    // Underline doesn't play nice with others
-    result = result + '+++<u>';
-  } else {
-    if (isBold) {
-      result = result + new Array(numOccurence).join('*');
-    }
-    if (isItalic) {
-      result = result + new Array(numOccurence).join('_');
-    }
-    if (isCode) {
-      result = result + '+';
-    }
+    result += '+++<u>+++'; // or asciidoc.css class: underline
+  }
+  if (isStrikethrough) {
+    result += '+++<s>+++'; // or asciidoc.css class: line-through
+  }
+  if (isBold) {
+    result = result + new Array(numOccurence).join('*');
+  }
+  if (isItalic) {
+    result = result + new Array(numOccurence).join('_');
+  }
+  if (isCode) {
+    result = result + '+';
   }
   // Content
-  result = result + distinctContent;
+  result += distinctContent;
   // Suffix markup
-  if (!isUnderline) {
-    if (isItalic) {
-      result = result + new Array(numOccurence).join('_');
-    }
-    if (isBold) {
-      result = result + new Array(numOccurence).join('*');
-    }
-    if (isCode) {
-      result = result + '+';
-    }
-  } else {
-    result = result + '</u>+++';
+  if (isCode) {
+    result = result + '+';
+  }
+  if (isItalic) {
+    result = result + new Array(numOccurence).join('_');
+  }
+  if (isBold) {
+    result = result + new Array(numOccurence).join('*');
+  }
+  if (isStrikethrough) {
+    result += '+++</s>+++';
+  }
+  if (isUnderline) {
+	  result += '+++</u>+++'
   }
   return result;
 }

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -151,7 +151,6 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
   var isItalic = text.isItalic(offset);
   var isUnderline = text.isUnderline(offset);
   var isStrikethrough = text.isStrikethrough(offset);
-  // var isPlain = ! (isBold || isItalic || isUnderline || isStrikethrough);
   // FIXME: getTextAttributeIndices doesn't split on different fonts,
   // makeing this almost useless
   var isCode = isTextCode(text);

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -151,15 +151,20 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
   var isItalic = text.isItalic(offset);
   var isUnderline = text.isUnderline(offset);
   var isStrikethrough = text.isStrikethrough(offset);
+  var htmlBuf = ''
   // FIXME: getTextAttributeIndices doesn't split on different fonts,
   // makeing this almost useless
   var isCode = isTextCode(text);
   // Prefix markup
   if (isUnderline) {
-    result += '+++<u>+++'; // or asciidoc.css class: underline
+    htmlBuf += '<u>'; // or asciidoc.css class: underline
   }
   if (isStrikethrough) {
-    result += '+++<s>+++'; // or asciidoc.css class: line-through
+    htmlBuf += '<s>'; // or asciidoc.css class: line-through
+  }
+  if (htmlBuf !== '') {
+  	result += '+++' + htmlBuf + '+++';
+  	htmlBuf = '';
   }
   if (isBold) {
     result = result + new Array(numOccurence).join('*');
@@ -183,12 +188,12 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
     result = result + new Array(numOccurence).join('*');
   }
   if (isStrikethrough) {
-    result += '+++</s>+++';
+    htmlBuf += '</s>';
   }
   if (isUnderline) {
-	  result += '+++</u>+++'
+	  htmlBuf += '</u>';
   }
-  return result;
+  return htmlBuf !== '' ? result + '+++' + htmlBuf + '+++' : result;
 }
 
 function asciidocHandleTitle(child) {

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -163,8 +163,8 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
     htmlBuf += '<s>'; // or asciidoc.css class: line-through
   }
   if (htmlBuf !== '') {
-  	result += '+++' + htmlBuf + '+++';
-  	htmlBuf = '';
+    result += '+++' + htmlBuf + '+++';
+    htmlBuf = '';
   }
   if (isBold) {
     result = result + new Array(numOccurence).join('*');
@@ -191,9 +191,12 @@ function asciidocHandleFontStyle(text, offset, distinctContent) {
     htmlBuf += '</s>';
   }
   if (isUnderline) {
-	  htmlBuf += '</u>';
+    htmlBuf += '</u>';
   }
-  return htmlBuf !== '' ? result + '+++' + htmlBuf + '+++' : result;
+  if (htmlBuf !== '') {
+    result += '+++' + htmlBuf + '+++';
+  }
+  return result;
 }
 
 function asciidocHandleTitle(child) {


### PR DESCRIPTION
In this PR, I implemented strike-through just as how underline is implemented. I also minified the `pass` or `+++SOMEHTML+++` area of HTML-expressed formats like underline and strike-through so it doesn't mess up with others.