### PR TITLE
Add anchors and spacing

### DIFF
--- a/app/Code.gs
+++ b/app/Code.gs
@@ -66,7 +66,7 @@ function asciidocify() {
       if (isCurrentCode) {
         if (typeof nextChild !== 'undefined' && isTextCode(nextChild.editAsText())) {
           // Start code block
-          asciidoc = asciidoc + '----\n';
+          asciidoc = asciidoc + '\n----\n';
           insideCodeBlock = true;
         }
       }
@@ -77,12 +77,12 @@ function asciidocify() {
         var isNextChildCode = isTextCode(nextChild.editAsText());
         if (!isNextChildCode) {
           // End code block
-          asciidoc = asciidoc + '\n----';
+          asciidoc = asciidoc + '\n----\n';
           insideCodeBlock = false;
         }
       } else {
         // End code block
-        asciidoc = asciidoc + '\n----';
+        asciidoc = asciidoc + '\n----\n';
         insideCodeBlock = false;
       }
     } else {

--- a/app/Code.gs
+++ b/app/Code.gs
@@ -218,7 +218,7 @@ function asciidocHandleTitle(child) {
     headingLevel = 7;
   }
   if (typeof headingLevel !== 'undefined') {
-    result = new Array(headingLevel + 1).join('=') + ' ' + child.getText() + '\n';
+    result = '\n[[' + child.getText().toLowerCase().replace(/\s/g,'-') + ']]\n' + new Array(headingLevel + 1).join('=') + ' ' + child.getText() + '\n';
   }
   return result;
 }


### PR DESCRIPTION
A couple little changes in these commits.

One just improves (I think) spacing around code listings.

The other prepends anchor slugs to every heading. I've found other tools doing this, and some output processors don't add anchors later, including [jekyll-asciidoc](https://github.com/asciidoctor/jekyll-asciidoc). I hope it's useful!